### PR TITLE
Enable 3D model upload and map display

### DIFF
--- a/src/main/java/dev/hamishapps/buildingarchive/servlets/BuildingManager.java
+++ b/src/main/java/dev/hamishapps/buildingarchive/servlets/BuildingManager.java
@@ -11,7 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 
-@WebServlet(name = "BuildingManager", urlPatterns = "/buildings")
+@WebServlet(name = "BuildingManager", urlPatterns = "/explore")
 public class BuildingManager extends HttpServlet {
     private final List<DataPoint> buildings = Persistency.getDataPoints();  // Assume Persistency is handling storage
 

--- a/src/main/webapp/explore.html
+++ b/src/main/webapp/explore.html
@@ -15,6 +15,8 @@
 <div id="container"></div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/OBJLoader.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
 <script>
     function fetchCameraData() {
         fetch('/camera')
@@ -29,7 +31,8 @@
 
     let scene, camera, renderer;
     let buildings = [];
-
+    let raycaster = new THREE.Raycaster();
+    let mouse = new THREE.Vector2();
 
 
     // Initialize the scene
@@ -52,7 +55,31 @@
         fetchCameraData();
         fetchBuildings();
 
+        renderer.domElement.addEventListener('click', onClick, false);
+
         animate();
+    }
+
+    function onClick(event) {
+        event.preventDefault();
+
+        mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+        mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+
+        raycaster.setFromCamera(mouse, camera);
+
+        let intersects = raycaster.intersectObjects(buildings, true); // Check buildings array, true for recursive
+
+        if (intersects.length > 0) {
+            // Traverse up to find the object with onClick, as intersects might be a child mesh
+            let clickedObject = intersects[0].object;
+            while (clickedObject && !clickedObject.onClick) {
+                clickedObject = clickedObject.parent;
+            }
+            if (clickedObject && clickedObject.onClick) {
+                clickedObject.onClick();
+            }
+        }
     }
 
     // Animation loop
@@ -83,22 +110,81 @@
 
     // Place building on the globe
     function placeBuildingOnGlobe(building) {
-        let { lat, lon, name } = building;
+        let { lat, lon, name, modelPath } = building; // modelPath is now expected
         let position = latLongToVector3(lat, lon);
 
-        let buildingGeometry = new THREE.BoxGeometry(0.2, 0.2, 0.2);  // Simplified 3D model
-        let buildingMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+        if (modelPath) {
+            const loadModel = (loader, path) => {
+                loader.load(
+                    path, // modelPath should be a URL like 'uploads/models/yourmodel.gltf'
+                    function (loadedModel) {
+                        let modelObject;
+                        if (loader instanceof THREE.GLTFLoader) {
+                            modelObject = loadedModel.scene;
+                        } else { // OBJLoader directly returns the object
+                            modelObject = loadedModel;
+                        }
+
+                        modelObject.position.copy(position);
+
+                        // Normalize and scale the model
+                        const box = new THREE.Box3().setFromObject(modelObject);
+                        const size = box.getSize(new THREE.Vector3());
+                        const center = box.getCenter(new THREE.Vector3());
+                        modelObject.position.x += (modelObject.position.x - center.x);
+                        modelObject.position.y += (modelObject.position.y - center.y);
+                        modelObject.position.z += (modelObject.position.z - center.z);
+
+                        const maxDim = Math.max(size.x, size.y, size.z);
+                        const scale = 0.1 / maxDim; // Adjust 0.1 to desired apparent size
+                        modelObject.scale.set(scale, scale, scale);
+
+                        modelObject.userData = { name, type: '3DModel' }; // Add original building data if needed
+                        scene.add(modelObject);
+                        buildings.push(modelObject); // Add for raycasting
+
+                        // If you need individual meshes for click, iterate through modelObject.children
+                        // For simplicity, we'll make the whole modelObject clickable if possible
+                        // This part might need adjustment based on how raycasting is set up
+                        modelObject.onClick = function() {
+                            displayBuildingDetails(building);
+                        };
+                    },
+                    undefined, // onProgress callback (optional)
+                    function (error) {
+                        console.error('Error loading model ' + name + ' from ' + path + ':', error);
+                        // Fallback to a cube if model loading fails
+                        createFallbackCube(position, name, building);
+                    }
+                );
+            };
+
+            if (modelPath.toLowerCase().endsWith('.gltf') || modelPath.toLowerCase().endsWith('.glb')) {
+                const loader = new THREE.GLTFLoader();
+                loadModel(loader, modelPath);
+            } else if (modelPath.toLowerCase().endsWith('.obj')) {
+                const loader = new THREE.OBJLoader();
+                loadModel(loader, modelPath);
+            } else {
+                console.warn('Unsupported model format for: ' + modelPath + '. Falling back to cube.');
+                createFallbackCube(position, name, building);
+            }
+        } else {
+            // No modelPath provided, use fallback cube
+            createFallbackCube(position, name, building);
+        }
+    }
+
+    function createFallbackCube(position, name, buildingDetails) {
+        let buildingGeometry = new THREE.BoxGeometry(0.2, 0.2, 0.2);
+        let buildingMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 }); // Red cube
         let buildingMesh = new THREE.Mesh(buildingGeometry, buildingMaterial);
-
         buildingMesh.position.copy(position);
-        buildingMesh.userData = { name };
-
+        buildingMesh.userData = { name, type: 'FallbackCube' };
         scene.add(buildingMesh);
         buildings.push(buildingMesh);
-
-        // Click detection
         buildingMesh.onClick = function() {
-            displayBuildingDetails(building);
+            displayBuildingDetails(buildingDetails);
         };
     }
 

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -12,7 +12,7 @@
         Building Archive
     </h1>
 
-    <form action="/upload" method="post">
+    <form action="/upload" method="post" enctype="multipart/form-data">
         <label>Name:</label>
         <input type="text" name="name" size="30">
         <label>Author's name:</label>
@@ -23,6 +23,8 @@
         <input type="number" name="latitude" size="30">
         <label>Longitude:</label>
         <input type="number" name="longitude" size="30">
+        <label>3D Model:</label>
+        <input type="file" name="modelFile" accept=".gltf,.glb,.obj">
         <input type="submit" value="Submit">
     </form>
 


### PR DESCRIPTION
This feature allows you to upload 3D models (GLTF, GLB, OBJ) along with their location data. These models are then displayed on an interactive 3D globe.

Key changes:
- Modified `index.html` to include a file input for 3D models and set form `enctype` to `multipart/form-data`.
- Updated `UploadForm.java` servlet to:
  - Handle multipart/form-data requests.
  - Save uploaded model files to an `uploads/models/` directory with unique filenames.
  - Store the relative path to the model in the `Building` object.
  - Redirect to `explore.html` after upload.
- Updated `BuildingManager.java` servlet to serve building data (including model paths) from the `/explore` endpoint, aligning with `explore.html`.
- Significantly enhanced `explore.html`:
  - Added `GLTFLoader` and `OBJLoader` from Three.js.
  - Replaced static cubes with loaded 3D models based on `modelPath`.
  - Implemented logic for model scaling, centering, and positioning on the globe.
  - Added robust raycasting for click interactions with the loaded 3D models.
  - Included a fallback to display a placeholder cube if a model is not specified or fails to load.
- Assumed default static file serving by the application server for the `uploads/models/` directory, deferring the need for a dedicated model-serving servlet.
- Provided a detailed manual testing plan to verify the new functionality.